### PR TITLE
Add test to Marketo lead calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -162,9 +162,61 @@ param | type | description
 
 ```js
 // Add leads 1, 2, and 3 to list id 1
-marketo.lead.addLeadsToList(1, [1, 2, 3])
+marketo.list.addLeadsToList(1, [1, 2, 3])
 
 
 // Same thing, in object form
-marketo.lead.addLeadsToList(1, [{id: 1}, {id: 2}, {id: 3}])
+marketo.list.addLeadsToList(1, [{id: 1}, {id: 2}, {id: 3}])
 ```
+
+
+# Test
+
+### Generating a replay for a test
+
+The initial run of the test has to be run against an actual API, the run (when
+in recording mode) should capture the API request/response data, which will then
+be used for future calls. What makes this a little tricky is Marketo API
+endpoints are unique per account, so we have to convert the captured data to
+something else for future purposes. We also need to remove credentials from
+these captures as well. Anyway, here's the annoying process of generating data:
+
+##### Running against the actual API
+
+The test looks at 4 environment variables when running, they are:
+
+- `MARKETO_ENDPOINT`
+- `MARKETO_IDENTITY`
+- `MARKETO_CLIENT_ID`
+- `MARKETO_CLIENT_SECRET`
+
+After setting these variables, run `npm run testRecord`.
+
+##### Stripping sensitive information
+
+Run the script `./scripts/strip-fixtures.sh`, which will convert the unique
+Marketo host over to `123-abc-456.mktorest.com` in addition to removing the
+capture that contains sensitive client id/secret file.
+
+##### Copy the data
+
+The data should now be moved over to `fixtures/123-abc-456.mktorest.com-443`,
+preferably with a useful name so it's easier to keep track of in the future.
+
+##### Tip
+
+We are using mocha to run the test, you can run a single test so that you
+generate only the needed data. To do so, you append `only` to a test:
+
+```js
+    // on a single unit test
+    it.only('test description, function() {})
+
+    // or an entire describe
+    describe.only('test description, function() {})
+```
+
+One more thing to note is that once we've processed the raw data, `node-replay`
+will not be able to map it back to the original raw request. This means that if
+you run `npm run testRecord`, you will be generating requests against Marketo's
+API directly. I highly recommend using `only`.

--- a/fixtures/123-abc-456.mktorest.com-443/find-by-multiple-ids
+++ b/fixtures/123-abc-456.mktorest.com-443/find-by-multiple-ids
@@ -1,0 +1,16 @@
+POST /rest/v1/leads.json
+accept: */*
+host: 123-abc-456.mktorest.com
+accept-encoding: gzip, deflate
+content-type: application/x-www-form-urlencoded
+body: filterType=id&filterValues=1%2C2&_method=GET
+
+200 HTTP/1.1
+server: nginx
+date: Wed, 19 Nov 2014 23:20:11 GMT
+content-type: application/json;charset=UTF-8
+content-length: 352
+connection: keep-alive
+set-cookie: BIGipServerab-restapi_https=587792650.47873.0000; path=/
+
+{"requestId":"d58c#149ca5b2794","result":[{"id":1,"updatedAt":"2014-11-13 12:43:04","lastName":"test","email":"ak+marketo1@usermind.com","createdAt":"2014-11-13 12:43:03","firstName":"AK1"},{"id":2,"updatedAt":"2014-11-13 15:25:36","lastName":null,"email":"ak+marketo2@usermind.com","createdAt":"2014-11-13 15:25:36","firstName":"ak2"}],"success":true}

--- a/fixtures/123-abc-456.mktorest.com-443/find-by-multiple-ids-and-retrieve-a-subset-of-fields
+++ b/fixtures/123-abc-456.mktorest.com-443/find-by-multiple-ids-and-retrieve-a-subset-of-fields
@@ -1,0 +1,16 @@
+POST /rest/v1/leads.json
+accept: */*
+host: 123-abc-456.mktorest.com
+accept-encoding: gzip, deflate
+content-type: application/x-www-form-urlencoded
+body: fields=email%2ClastName&filterType=id&filterValues=1%2C2&_method=GET
+
+200 HTTP/1.1
+server: nginx
+date: Wed, 19 Nov 2014 23:43:07 GMT
+content-type: application/json;charset=UTF-8
+content-length: 180
+connection: keep-alive
+set-cookie: BIGipServerab-restapi_https=571015434.47873.0000; path=/
+
+{"requestId":"57ad#149ca702500","result":[{"id":1,"lastName":"test","email":"ak+marketo1@usermind.com"},{"id":2,"lastName":null,"email":"ak+marketo2@usermind.com"}],"success":true}

--- a/fixtures/123-abc-456.mktorest.com-443/find-by-single-id
+++ b/fixtures/123-abc-456.mktorest.com-443/find-by-single-id
@@ -1,0 +1,16 @@
+POST /rest/v1/leads.json
+accept: */*
+host: 123-abc-456.mktorest.com
+accept-encoding: gzip, deflate
+content-type: application/x-www-form-urlencoded
+body: filterType=id&filterValues=1&_method=GET
+
+200 HTTP/1.1
+server: nginx
+date: Wed, 19 Nov 2014 23:18:44 GMT
+content-type: application/json;charset=UTF-8
+content-length: 206
+connection: keep-alive
+set-cookie: BIGipServerab-restapi_https=587792650.47873.0000; path=/
+
+{"requestId":"6365#149ca59d38a","result":[{"id":1,"updatedAt":"2014-11-13 12:43:04","lastName":"test","email":"ak+marketo1@usermind.com","createdAt":"2014-11-13 12:43:03","firstName":"AK1"}],"success":true}

--- a/fixtures/123-abc-456.mktorest.com-443/get-oauth-creds
+++ b/fixtures/123-abc-456.mktorest.com-443/get-oauth-creds
@@ -1,0 +1,16 @@
+GET /identity/oauth/token?grant_type=client_credentials&client_id=someId&client_secret=someSecret
+accept: */*
+host: 123-abc-456.mktorest.com
+accept-encoding: gzip, deflate
+
+200 HTTP/1.1
+server: nginx
+date: Wed, 19 Nov 2014 21:36:57 GMT
+content-type: application/json;charset=UTF-8
+transfer-encoding: chunked
+connection: keep-alive
+cache-control: no-store
+pragma: no-cache
+set-cookie: BIGipServerab-restapi_https=587792650.47873.0000; path=/
+
+{"access_token":"foobar","token_type":"bearer","expires_in":516,"scope":"ak+marketoapiuser@usermind.com"}

--- a/fixtures/123-abc-456.mktorest.com-443/lead-by-id-1
+++ b/fixtures/123-abc-456.mktorest.com-443/lead-by-id-1
@@ -1,0 +1,15 @@
+GET /rest/v1/lead/1.json
+accept: */*
+host: 123-abc-456.mktorest.com
+accept-encoding: gzip, deflate
+authorization: Bearer bda399e0-a68e-4d9b-bc2f-aa2657746b06:ablakjsdlaskjdfl
+
+200 HTTP/1.1
+server: nginx
+date: Wed, 19 Nov 2014 21:36:58 GMT
+content-type: application/json;charset=UTF-8
+content-length: 207
+connection: keep-alive
+set-cookie: BIGipServerab-restapi_https=571015434.47873.0000; path=/
+
+{"requestId":"13a14#149c9fca60e","result":[{"id":1,"updatedAt":"2014-11-13 12:43:04","lastName":"test","email":"ak+marketo1@usermind.com","createdAt":"2014-11-13 12:43:03","firstName":"AK1"}],"success":true}

--- a/fixtures/123-abc-456.mktorest.com-443/lead-by-id-with-email-filter
+++ b/fixtures/123-abc-456.mktorest.com-443/lead-by-id-with-email-filter
@@ -1,0 +1,14 @@
+GET /rest/v1/lead/1.json?fields=email
+accept: */*
+host: 123-abc-456.mktorest.com
+accept-encoding: gzip, deflate
+
+200 HTTP/1.1
+server: nginx
+date: Wed, 19 Nov 2014 22:59:54 GMT
+content-type: application/json;charset=UTF-8
+content-length: 102
+connection: keep-alive
+set-cookie: BIGipServerab-restapi_https=571015434.47873.0000; path=/
+
+{"requestId":"6ff6#149ca4892e0","result":[{"id":1,"email":"ak+marketo1@usermind.com"}],"success":true}

--- a/fixtures/123-abc-456.mktorest.com-443/lead-by-id-with-multiple-filters
+++ b/fixtures/123-abc-456.mktorest.com-443/lead-by-id-with-multiple-filters
@@ -1,0 +1,14 @@
+GET /rest/v1/lead/1.json?fields=email%2ClastName
+accept: */*
+host: 123-abc-456.mktorest.com
+accept-encoding: gzip, deflate
+
+200 HTTP/1.1
+server: nginx
+date: Wed, 19 Nov 2014 23:15:13 GMT
+content-type: application/json;charset=UTF-8
+content-length: 121
+connection: keep-alive
+set-cookie: BIGipServerab-restapi_https=587792650.47873.0000; path=/
+
+{"requestId":"179d7#149ca5697d6","result":[{"id":1,"lastName":"test","email":"ak+marketo1@usermind.com"}],"success":true}

--- a/fixtures/123-abc-456.mktorest.com-443/updates-existing-record-by-email
+++ b/fixtures/123-abc-456.mktorest.com-443/updates-existing-record-by-email
@@ -1,0 +1,16 @@
+POST /rest/v1/leads.json
+accept: */*
+host: 123-abc-456.mktorest.com
+accept-encoding: gzip, deflate
+content-type: application/json
+body: {\"lookupField\":\"email\",\"input\":[{\"email\":\"ak+marketo1@usermind.com\"}]}
+
+200 HTTP/1.1
+server: nginx
+date: Wed, 19 Nov 2014 23:50:30 GMT
+content-type: application/json;charset=UTF-8
+content-length: 87
+connection: keep-alive
+set-cookie: BIGipServerab-restapi_https=587792650.47873.0000; path=/
+
+{"requestId":"174ac#149ca76e153","result":[{"id":1,"status":"updated"}],"success":true}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "engines": {
     "node": ">=0.10.29"
   },
+  "scripts": {
+    "test": "mocha test/*test.js",
+    "testRecord": "REPLAY=record mocha -t 10000 test/*test.js"
+  },
   "dependencies": {
     "bluebird": "2.3.x",
     "bunyan": "1.0.x",
@@ -17,5 +21,7 @@
     "restler": "3.1.x"
   },
   "devDependencies": {
+    "mocha": "2.0.x",
+    "replay": "1.11.x"
   }
 }

--- a/scripts/strip-fixtures.sh
+++ b/scripts/strip-fixtures.sh
@@ -1,0 +1,23 @@
+TO_HOST=123-abc-456.mktorest.com
+TO_HOST_DIR=$TO_HOST-443
+TO_CLIENT_ID=someId
+TO_CLIENT_SECRET=someSecret
+
+cd fixtures
+mkdir -p $TO_HOST_DIR
+
+# move all recorded files into $HOST directory
+DIRS=$(ls -d */ | grep -v ${TO_HOST})
+
+for FROM_HOST in $DIRS; do
+  # remove the oauth file
+  rm `grep 'identity/oauth/token' $FROM_HOST/* -l`
+
+  FROM_HOST_DIR=$(echo $FROM_HOST | sed 's/\/$//')
+  FROM_HOST=$(echo $FROM_HOST | sed 's/-443\/$//')
+  for j in $(find $FROM_HOST_DIR -not -path $FROM_HOST_DIR); do
+    sed -i "s/$FROM_HOST/$TO_HOST/g" $j
+    sed -i "s/$FROM_CLIENT_ID/$TO_CLIENT_ID/g" $j
+    sed -i "s/$FROM_CLIENT_SECRET/$TO_CLIENT_SECRET/g" $j
+  done
+done;

--- a/test/helper/config.js
+++ b/test/helper/config.js
@@ -1,0 +1,23 @@
+var _ = require('lodash'),
+    env = process.env,
+    defaults = {
+      endpoint: 'https://123-ABC-456.mktorest.com/rest',
+      identity: 'https://123-ABC-456.mktorest.com/identity',
+      clientId: 'someId',
+      clientSecret: 'someSecret'
+    },
+    credentials;
+
+credentials = {
+  endpoint: env.MARKETO_ENDPOINT || defaults.endpoint,
+  identity: env.MARKETO_IDENTITY || defaults.identity,
+  clientId: env.MARKETO_CLIENT_ID || defaults.clientId,
+  clientSecret: env.MARKETO_CLIENT_SECRET || defaults.clientSecret
+};
+
+module.exports = {
+  creds: {
+    defaults: defaults,
+    computed: credentials
+  }
+};

--- a/test/helper/connection.js
+++ b/test/helper/connection.js
@@ -1,0 +1,11 @@
+var _ = require('lodash'),
+    Replay = require('replay'),
+    config = require('./config'),
+    Marketo = require('../../index');
+
+// Remove authorization from the header comparison
+Replay.headers = _.filter(Replay.headers, function(header) {
+  return !(header.toString() === '/^authorization/');
+});
+
+module.exports = new Marketo(config.creds.computed);

--- a/test/leads.test.js
+++ b/test/leads.test.js
@@ -1,0 +1,93 @@
+var assert = require('assert'),
+    _ = require('lodash'),
+    marketo = require('./helper/connection');
+
+describe('Leads', function() {
+  describe('#byId', function() {
+    it('finds a lead by id only', function(done) {
+      marketo.lead.byId(1).spread(function(response) {
+        assert.equal(response.result.length, 1);
+        assert.equal(response.result[0].id, 1);
+        assert(_.has(response.result[0], 'email'));
+        assert(_.has(response.result[0], 'lastName'));
+        done();
+      });
+    });
+
+    it('finds a lead but only retrieve the email field', function(done) {
+      marketo.lead.byId(1, {fields: ['email']}).spread(function(resp) {
+        assert.equal(resp.result.length, 1);
+
+        var lead = resp.result[0];
+        assert.equal(lead.id, 1);
+        assert.equal(_.keys(lead).length, 2);
+        assert(_.has(lead, 'email'));
+        assert(!_.has(lead, 'lastName'));
+        done();
+      });
+    });
+
+    it('finds a lead and retrieve a subset of fields using csv', function(done) {
+      marketo.lead.byId(1, {fields: 'email,lastName'}).spread(function(resp) {
+        assert.equal(resp.result.length, 1);
+
+        var lead = resp.result[0];
+        assert.equal(lead.id, 1);
+        assert.equal(_.keys(lead).length, 3);
+        assert(_.has(lead, 'email'));
+        assert(_.has(lead, 'lastName'));
+        done();
+      });
+    });
+  });
+
+  describe('#find', function() {
+    it('uses a single filter value', function(done) {
+      marketo.lead.find('id', [1]).spread(function(resp) {
+        assert.equal(resp.result.length, 1);
+
+        var lead = resp.result[0];
+        assert.equal(lead.id, 1);
+        assert(_.has(lead, 'email'));
+        assert(_.has(lead, 'lastName'));
+        done();
+      });
+    });
+
+    it('uses multiple filter values', function(done) {
+      marketo.lead.find('id', [1,2]).spread(function(resp) {
+        assert.equal(resp.result.length, 2);
+        assert.equal(resp.result[0].id, 1);
+        assert.equal(resp.result[1].id, 2);
+        done();
+      });
+    });
+
+
+    it('uses multiple filter values and retrieve a subset of fields', function(done) {
+      marketo.lead.find('id', [1,2], {fields: ['email', 'lastName']}).spread(function(resp) {
+        assert.equal(resp.result.length, 2);
+        assert.equal(resp.result[0].id, 1);
+        assert.equal(resp.result[1].id, 2);
+
+        var lead = resp.result[0];
+        assert.equal(lead.id, 1);
+        assert(_.has(lead, 'email'));
+        assert(_.has(lead, 'lastName'));
+        done();
+      });
+    });
+  });
+
+  describe('#createOrUpdate', function() {
+    it('updates an existing record by using an email', function(done) {
+      marketo.lead.createOrUpdate([{email: 'ak+marketo1@usermind.com'}], {lookupField: 'email'})
+        .spread(function(resp) {
+          assert.equal(resp.result.length, 1);
+          assert.equal(resp.result[0].id, 1);
+          assert.equal(resp.result[0].status, 'updated');
+          done();
+        });
+    })
+  });
+});


### PR DESCRIPTION
This introduces 'node-replay', which allows us to capture actual API
calls to Marketo and replay it back to us in future test runs

UM-85
